### PR TITLE
Don't use `assert meta != null`

### DIFF
--- a/src/main/java/me/jadenp/notbounties/ui/gui/CustomItem.java
+++ b/src/main/java/me/jadenp/notbounties/ui/gui/CustomItem.java
@@ -65,7 +65,7 @@ public class CustomItem {
         if (itemStack == null)
             return null;
         ItemMeta meta = itemStack.getItemMeta();
-        assert meta != null;
+        if (meta == null) return itemStack;
         if (name != null)
             meta.setDisplayName(parse(color(name.replaceAll("\\{leaderboard}", replacements[0])), player));
         if (!lore.isEmpty()) {


### PR DESCRIPTION
Not all items actually have meta (such as AIR), so it's best to just return the ItemStack if it doesn't
*Also, `assert` should only ever be used in testing, as it causes errors such as these to occur in production*