### PR TITLE
Fix for null island

### DIFF
--- a/src/main/java/me/jadenp/notbounties/utils/external_api/SuperiorSkyblockClass.java
+++ b/src/main/java/me/jadenp/notbounties/utils/external_api/SuperiorSkyblockClass.java
@@ -1,11 +1,13 @@
 package me.jadenp.notbounties.utils.external_api;
 
 import com.bgsoftware.superiorskyblock.api.SuperiorSkyblockAPI;
+import com.bgsoftware.superiorskyblock.api.island.Island;
 import org.bukkit.entity.Player;
 
 public class SuperiorSkyblockClass {
     private SuperiorSkyblockClass() {}
     public static boolean onSameIsland(Player player1, Player player2) {
-        return SuperiorSkyblockAPI.getPlayer(player1).getIsland().isMember(SuperiorSkyblockAPI.getPlayer(player2));
+        Island island = SuperiorSkyblockAPI.getPlayer(player1).getIsland();
+        return island != null && island.isMember(SuperiorSkyblockAPI.getPlayer(player2));
     }
 }


### PR DESCRIPTION
This PR simply fixes the null pointer exception on the player death whenever the dead player doesn't have an island.