### PR TITLE
Fixed player data saving on the main thread

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,7 @@
         <dependency>
             <groupId>com.github.dumbo-the-developer.Duels</groupId>
             <artifactId>duels-api</artifactId>
-            <version>2.8</version>
+            <version>4.0</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/src/main/java/me/jadenp/notbounties/ui/Events.java
+++ b/src/main/java/me/jadenp/notbounties/ui/Events.java
@@ -75,10 +75,8 @@ public class Events implements Listener {
         if (System.currentTimeMillis() - lastSeen > 1000 * 60) {
             // update player data if they have been online for more than a minute
             NotBounties.debugMessage("Updating player data for " + playerData.getPlayerName(), false);
-            DataManager.syncPlayerData(event.getPlayer().getUniqueId(), null);
+            NotBounties.getServerImplementation().async().runNow(() -> DataManager.syncPlayerData(event.getPlayer().getUniqueId(), null));
         }
-
-
     }
 
     @EventHandler


### PR DESCRIPTION
Modified the player quit event handler in `Events.java` to run `DataManager.syncPlayerData` asynchronously, preventing potential blocking of the main server thread during player data updates. Also, updated the duels api version.